### PR TITLE
Isolate report consumer worker & handle a error

### DIFF
--- a/internal/service/report.go
+++ b/internal/service/report.go
@@ -65,7 +65,7 @@ func NewReportService(db *bun.DB, redisClient *redis.Client, natsJs nats.JetStre
 	return service
 }
 
-func (s *ReportService) startConsumerWorkers(NumWorker int) {
+func (s *ReportService) startConsumerWorkers(numWorker int) {
 	ch := make(chan error)
 	go func() {
 		for {
@@ -73,7 +73,7 @@ func (s *ReportService) startConsumerWorkers(NumWorker int) {
 			spew.Dump(err)
 		}
 	}()
-	for i := 0; i < NumWorker; i++ {
+	for i := 0; i < numWorker; i++ {
 		go func() {
 			err := s.ReportConsumeWorker(context.Background(), ch)
 			if err != nil {

--- a/internal/service/report.go
+++ b/internal/service/report.go
@@ -61,28 +61,26 @@ func NewReportService(db *bun.DB, redisClient *redis.Client, natsJs nats.JetStre
 		DropPatternElementRepo: dropPatternElementRepo,
 		ReportVerifier:         reportVerifier,
 	}
+	go service.startConsumerWorkers(runtime.NumCPU())
+	return service
+}
 
-	// TODO: isolate report consumer as standalone workers
+func (s *ReportService) startConsumerWorkers(NumWorker int) {
+	ch := make(chan error)
 	go func() {
-		ch := make(chan error)
-
-		go func() {
-			for {
-				err := <-ch
-				spew.Dump(err)
-			}
-		}()
-
-		for i := 0; i < runtime.NumCPU(); i++ {
-			go func() {
-				err := service.ReportConsumeWorker(context.Background(), ch)
-				if err != nil {
-					ch <- err
-				}
-			}()
+		for {
+			err := <-ch
+			spew.Dump(err)
 		}
 	}()
-	return service
+	for i := 0; i < NumWorker; i++ {
+		go func() {
+			err := s.ReportConsumeWorker(context.Background(), ch)
+			if err != nil {
+				ch <- err
+			}
+		}()
+	}
 }
 
 func (s *ReportService) pipelineAccount(ctx *fiber.Ctx) (accountId int, err error) {
@@ -275,7 +273,10 @@ func (s *ReportService) ReportConsumeWorker(ctx context.Context, ch chan error) 
 			func() {
 				taskCtx, cancelTask := context.WithDeadline(ctx, time.Now().Add(time.Second*10))
 				inprogressInformer := time.AfterFunc(time.Second*5, func() {
-					msg.InProgress()
+					err = msg.InProgress()
+					if err != nil {
+						log.Error().Err(err).Msg("failed to set msg InProgress")
+					}
 				})
 				defer func() {
 					inprogressInformer.Stop()


### PR DESCRIPTION
Isolate the initiation of workers of NewReportService to a standalone function. Provide variability for the number of workers.