### PR TITLE
feat: isolate the spawn of report consumer workers and service

### DIFF
--- a/internal/appentry/appentry.go
+++ b/internal/appentry/appentry.go
@@ -1,6 +1,7 @@
 package appentry
 
 import (
+	"github.com/penguin-statistics/backend-next/internal/workers/reportwkr"
 	"time"
 
 	"go.uber.org/fx"
@@ -124,6 +125,7 @@ func ProvideOptions(includeSwagger bool) []fx.Option {
 
 		// Workers
 		fx.Invoke(calcwkr.Start),
+		fx.Invoke(reportwkr.Start),
 
 		// fx Extra Options
 		fx.StartTimeout(1 * time.Second),

--- a/internal/service/report.go
+++ b/internal/service/report.go
@@ -5,24 +5,19 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/dchest/uniuri"
 	"github.com/go-redis/redis/v8"
 	"github.com/gofiber/fiber/v2"
 	"github.com/nats-io/nats.go"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
-	"github.com/uptrace/bun"
-	"gopkg.in/guregu/null.v3"
-
 	"github.com/penguin-statistics/backend-next/internal/constant"
-	"github.com/penguin-statistics/backend-next/internal/model"
 	"github.com/penguin-statistics/backend-next/internal/model/types"
 	"github.com/penguin-statistics/backend-next/internal/pkg/pgerr"
 	"github.com/penguin-statistics/backend-next/internal/pkg/pgid"
 	"github.com/penguin-statistics/backend-next/internal/repo"
 	"github.com/penguin-statistics/backend-next/internal/util"
 	"github.com/penguin-statistics/backend-next/internal/util/reportutil"
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
 )
 
 var (
@@ -237,155 +232,4 @@ func (s *Report) RecallSingularReport(ctx context.Context, req *types.SingleRepo
 	s.Redis.Del(ctx, req.ReportHash)
 
 	return nil
-}
-
-func (s *Report) ReportConsumeWorker(ctx context.Context, ch chan error) error {
-	msgChan := make(chan *nats.Msg, 16)
-
-	_, err := s.NatsJS.ChanQueueSubscribe("REPORT.*", "penguin-reports", msgChan, nats.AckWait(time.Second*10), nats.MaxAckPending(128))
-	if err != nil {
-		log.Err(err).Msg("failed to subscribe to REPORT.*")
-		return err
-	}
-
-	for {
-		select {
-		case msg := <-msgChan:
-			func() {
-				taskCtx, cancelTask := context.WithDeadline(ctx, time.Now().Add(time.Second*10))
-				inprogressInformer := time.AfterFunc(time.Second*5, func() {
-					err = msg.InProgress()
-					if err != nil {
-						log.Error().Err(err).Msg("failed to set msg InProgress")
-					}
-				})
-				defer func() {
-					inprogressInformer.Stop()
-					cancelTask()
-					if err := msg.Ack(); err != nil {
-						log.Error().Err(err).Msg("failed to ack")
-					}
-				}()
-
-				reportTask := &types.ReportTask{}
-				if err := json.Unmarshal(msg.Data, reportTask); err != nil {
-					ch <- err
-					return
-				}
-
-				err = s.consumeReportTask(taskCtx, reportTask)
-				if err != nil {
-					log.Error().
-						Err(err).
-						Str("taskId", reportTask.TaskID).
-						Str("reportTask", spew.Sdump(reportTask)).
-						Msg("failed to consume report task")
-					ch <- err
-					return
-				}
-
-				log.Info().Str("taskId", reportTask.TaskID).Msg("report task processed successfully")
-			}()
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
-func (s *Report) consumeReportTask(ctx context.Context, reportTask *types.ReportTask) error {
-	L := log.With().
-		Interface("task", reportTask).
-		Logger()
-
-	L.Info().Msg("now processing new report task")
-	taskReliability := 0
-	if errs := s.ReportVerifier.Verify(ctx, reportTask); len(errs) > 0 {
-		// TODO: use different error code for different types of error
-		taskReliability = 1
-		L.Warn().
-			Interface("errors", errs).
-			Msg("report task verification failed, marking task as unreliable")
-	}
-
-	// reportTask.CreatedAt is in microseconds
-	var taskCreatedAt time.Time
-	if reportTask.CreatedAt != 0 {
-		taskCreatedAt = time.UnixMicro(reportTask.CreatedAt)
-	} else {
-		taskCreatedAt = time.Now()
-	}
-
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	intendedCommit := false
-	defer func() {
-		if !intendedCommit {
-			L.Warn().Msg("rolling back transaction due to error")
-			if err := tx.Rollback(); err != nil {
-				L.Error().Err(err).Msg("failed to rollback transaction")
-			}
-		}
-	}()
-
-	// calculate drop pattern hash for each report
-	for _, report := range reportTask.Reports {
-		dropPattern, created, err := s.DropPatternRepo.GetOrCreateDropPatternFromDrops(ctx, tx, report.Drops)
-		if err != nil {
-			return err
-		}
-		if created {
-			_, err := s.DropPatternElementRepo.CreateDropPatternElements(ctx, tx, dropPattern.PatternID, report.Drops)
-			if err != nil {
-				return err
-			}
-		}
-
-		// FIXME: the param is context.Context, so we have to use repo here, can we change it to use context.Context?
-		// unable: consumer workers are not able to use context.Context as ops here are not initiated due to a fiber request,
-		// but rather a message dispatch
-		stage, err := s.StageService.StageRepo.GetStageByArkId(ctx, report.StageID)
-		if err != nil {
-			return err
-		}
-		dropReport := &model.DropReport{
-			StageID:     stage.StageID,
-			PatternID:   dropPattern.PatternID,
-			Times:       report.Times,
-			CreatedAt:   &taskCreatedAt,
-			Reliability: taskReliability,
-			Server:      reportTask.Server,
-			AccountID:   reportTask.AccountID,
-		}
-		if err = s.DropReportRepo.CreateDropReport(ctx, tx, dropReport); err != nil {
-			return err
-		}
-
-		var md5 null.String
-		if report.Metadata != nil {
-			md5 = report.Metadata.MD5
-		}
-		if reportTask.IP == "" {
-			// FIXME: temporary hack; find why ip is empty
-			reportTask.IP = "127.0.0.1"
-		}
-		if err = s.DropReportExtraRepo.CreateDropReportExtra(ctx, tx, &model.DropReportExtra{
-			ReportID: dropReport.ReportID,
-			IP:       reportTask.IP,
-			Source:   reportTask.Source,
-			Version:  reportTask.Version,
-			Metadata: report.Metadata,
-			MD5:      md5,
-		}); err != nil {
-			return err
-		}
-
-		if err := s.Redis.Set(ctx, reportTask.TaskID, dropReport.ReportID, time.Hour*24).Err(); err != nil {
-			return err
-		}
-	}
-
-	intendedCommit = true
-	return tx.Commit()
 }

--- a/internal/service/report.go
+++ b/internal/service/report.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"encoding/json"
-	"runtime"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -61,26 +60,7 @@ func NewReport(db *bun.DB, redisClient *redis.Client, natsJs nats.JetStreamConte
 		DropPatternElementRepo: dropPatternElementRepo,
 		ReportVerifier:         reportVerifier,
 	}
-	go service.startConsumerWorkers(runtime.NumCPU())
 	return service
-}
-
-func (s *Report) startConsumerWorkers(numWorker int) {
-	ch := make(chan error)
-	go func() {
-		for {
-			err := <-ch
-			spew.Dump(err)
-		}
-	}()
-	for i := 0; i < numWorker; i++ {
-		go func() {
-			err := s.ReportConsumeWorker(context.Background(), ch)
-			if err != nil {
-				ch <- err
-			}
-		}()
-	}
 }
 
 func (s *Report) pipelineAccount(ctx *fiber.Ctx) (accountId int, err error) {

--- a/internal/workers/reportwkr/reportwkr.go
+++ b/internal/workers/reportwkr/reportwkr.go
@@ -1,0 +1,50 @@
+package reportwkr
+
+import (
+	"context"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/penguin-statistics/backend-next/internal/config"
+	"github.com/penguin-statistics/backend-next/internal/service"
+	"go.uber.org/fx"
+	"runtime"
+)
+
+type ReportConsumerDeps struct {
+	fx.In
+	ReportServices *service.Report
+}
+
+type ReportConsumerWorker struct {
+	// count is the number of workers
+	numWorker int
+
+	ReportConsumerDeps
+}
+
+func Start(conf *config.Config, deps ReportConsumerDeps) {
+	ch := make(chan error)
+	// handle & dump errors from workers
+	go func() {
+		for {
+			err := <-ch
+			spew.Dump(err)
+		}
+	}()
+	// works like a consumer factory
+	reportWorkers := &ReportConsumerWorker{
+		numWorker:          0,
+		ReportConsumerDeps: deps,
+	}
+	// spawn workers
+	// maybe we should specify the number of worker in config.Config ?
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			err := reportWorkers.ReportServices.ReportConsumeWorker(context.Background(), ch)
+			if err != nil {
+				ch <- err
+			}
+		}()
+		// update current worker count
+		reportWorkers.numWorker += 1
+	}
+}

--- a/internal/workers/reportwkr/reportwkr.go
+++ b/internal/workers/reportwkr/reportwkr.go
@@ -2,11 +2,18 @@ package reportwkr
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/nats-io/nats.go"
 	"github.com/penguin-statistics/backend-next/internal/config"
+	"github.com/penguin-statistics/backend-next/internal/model"
+	"github.com/penguin-statistics/backend-next/internal/model/types"
 	"github.com/penguin-statistics/backend-next/internal/service"
+	"github.com/rs/zerolog/log"
 	"go.uber.org/fx"
+	"gopkg.in/guregu/null.v3"
 	"runtime"
+	"time"
 )
 
 type WorkerDeps struct {
@@ -39,7 +46,7 @@ func Start(conf *config.Config, deps WorkerDeps) {
 	// maybe we should specify the number of worker in config.Config ?
 	for i := 0; i < runtime.NumCPU(); i++ {
 		go func() {
-			err := reportWorkers.ReportServices.ReportConsumeWorker(context.Background(), ch)
+			err := reportWorkers.Consumer(context.Background(), ch)
 			if err != nil {
 				ch <- err
 			}
@@ -47,4 +54,155 @@ func Start(conf *config.Config, deps WorkerDeps) {
 		// update current worker count
 		reportWorkers.count += 1
 	}
+}
+
+func (w *Worker) Consumer(ctx context.Context, ch chan error) error {
+	msgChan := make(chan *nats.Msg, 16)
+
+	_, err := w.ReportServices.NatsJS.ChanQueueSubscribe("REPORT.*", "penguin-reports", msgChan, nats.AckWait(time.Second*10), nats.MaxAckPending(128))
+	if err != nil {
+		log.Err(err).Msg("failed to subscribe to REPORT.*")
+		return err
+	}
+
+	for {
+		select {
+		case msg := <-msgChan:
+			func() {
+				taskCtx, cancelTask := context.WithDeadline(ctx, time.Now().Add(time.Second*10))
+				inprogressInformer := time.AfterFunc(time.Second*5, func() {
+					err = msg.InProgress()
+					if err != nil {
+						log.Error().Err(err).Msg("failed to set msg InProgress")
+					}
+				})
+				defer func() {
+					inprogressInformer.Stop()
+					cancelTask()
+					if err := msg.Ack(); err != nil {
+						log.Error().Err(err).Msg("failed to ack")
+					}
+				}()
+
+				reportTask := &types.ReportTask{}
+				if err := json.Unmarshal(msg.Data, reportTask); err != nil {
+					ch <- err
+					return
+				}
+
+				err = w.consumeReport(taskCtx, reportTask)
+				if err != nil {
+					log.Error().
+						Err(err).
+						Str("taskId", reportTask.TaskID).
+						Str("reportTask", spew.Sdump(reportTask)).
+						Msg("failed to consume report task")
+					ch <- err
+					return
+				}
+
+				log.Info().Str("taskId", reportTask.TaskID).Msg("report task processed successfully")
+			}()
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (w *Worker) consumeReport(ctx context.Context, reportTask *types.ReportTask) error {
+	L := log.With().
+		Interface("task", reportTask).
+		Logger()
+
+	L.Info().Msg("now processing new report task")
+	taskReliability := 0
+	if errs := w.ReportServices.ReportVerifier.Verify(ctx, reportTask); len(errs) > 0 {
+		// TODO: use different error code for different types of error
+		taskReliability = 1
+		L.Warn().
+			Interface("errors", errs).
+			Msg("report task verification failed, marking task as unreliable")
+	}
+
+	// reportTask.CreatedAt is in microseconds
+	var taskCreatedAt time.Time
+	if reportTask.CreatedAt != 0 {
+		taskCreatedAt = time.UnixMicro(reportTask.CreatedAt)
+	} else {
+		taskCreatedAt = time.Now()
+	}
+
+	tx, err := w.ReportServices.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	intendedCommit := false
+	defer func() {
+		if !intendedCommit {
+			L.Warn().Msg("rolling back transaction due to error")
+			if err := tx.Rollback(); err != nil {
+				L.Error().Err(err).Msg("failed to rollback transaction")
+			}
+		}
+	}()
+
+	// calculate drop pattern hash for each report
+	for _, report := range reportTask.Reports {
+		dropPattern, created, err := w.ReportServices.DropPatternRepo.GetOrCreateDropPatternFromDrops(ctx, tx, report.Drops)
+		if err != nil {
+			return err
+		}
+		if created {
+			_, err := w.ReportServices.DropPatternElementRepo.CreateDropPatternElements(ctx, tx, dropPattern.PatternID, report.Drops)
+			if err != nil {
+				return err
+			}
+		}
+
+		// FIXME: the param is context.Context, so we have to use repo here, can we change it to use context.Context?
+		// unable: consumer workers are not able to use context.Context as ops here are not initiated due to a fiber request,
+		// but rather a message dispatch
+		stage, err := w.ReportServices.StageService.StageRepo.GetStageByArkId(ctx, report.StageID)
+		if err != nil {
+			return err
+		}
+		dropReport := &model.DropReport{
+			StageID:     stage.StageID,
+			PatternID:   dropPattern.PatternID,
+			Times:       report.Times,
+			CreatedAt:   &taskCreatedAt,
+			Reliability: taskReliability,
+			Server:      reportTask.Server,
+			AccountID:   reportTask.AccountID,
+		}
+		if err = w.ReportServices.DropReportRepo.CreateDropReport(ctx, tx, dropReport); err != nil {
+			return err
+		}
+
+		var md5 null.String
+		if report.Metadata != nil {
+			md5 = report.Metadata.MD5
+		}
+		if reportTask.IP == "" {
+			// FIXME: temporary hack; find why ip is empty
+			reportTask.IP = "127.0.0.1"
+		}
+		if err = w.ReportServices.DropReportExtraRepo.CreateDropReportExtra(ctx, tx, &model.DropReportExtra{
+			ReportID: dropReport.ReportID,
+			IP:       reportTask.IP,
+			Source:   reportTask.Source,
+			Version:  reportTask.Version,
+			Metadata: report.Metadata,
+			MD5:      md5,
+		}); err != nil {
+			return err
+		}
+
+		if err := w.ReportServices.Redis.Set(ctx, reportTask.TaskID, dropReport.ReportID, time.Hour*24).Err(); err != nil {
+			return err
+		}
+	}
+
+	intendedCommit = true
+	return tx.Commit()
 }

--- a/internal/workers/reportwkr/reportwkr.go
+++ b/internal/workers/reportwkr/reportwkr.go
@@ -9,19 +9,19 @@ import (
 	"runtime"
 )
 
-type ReportConsumerDeps struct {
+type WorkerDeps struct {
 	fx.In
 	ReportServices *service.Report
 }
 
-type ReportConsumerWorker struct {
+type Worker struct {
 	// count is the number of workers
-	numWorker int
+	count int
 
-	ReportConsumerDeps
+	WorkerDeps
 }
 
-func Start(conf *config.Config, deps ReportConsumerDeps) {
+func Start(conf *config.Config, deps WorkerDeps) {
 	ch := make(chan error)
 	// handle & dump errors from workers
 	go func() {
@@ -31,9 +31,9 @@ func Start(conf *config.Config, deps ReportConsumerDeps) {
 		}
 	}()
 	// works like a consumer factory
-	reportWorkers := &ReportConsumerWorker{
-		numWorker:          0,
-		ReportConsumerDeps: deps,
+	reportWorkers := &Worker{
+		count:      0,
+		WorkerDeps: deps,
 	}
 	// spawn workers
 	// maybe we should specify the number of worker in config.Config ?
@@ -45,6 +45,6 @@ func Start(conf *config.Config, deps ReportConsumerDeps) {
 			}
 		}()
 		// update current worker count
-		reportWorkers.numWorker += 1
+		reportWorkers.count += 1
 	}
 }


### PR DESCRIPTION
further isolate the report consumer worker spawn and report service.  

Reason: Since the calc workers are spawned separately, so should the report consumer workers. 

And maybe we can specify the number of workers in config.Config and add an environment variable when starting the whole server? And we can intentionally leave it blank to use the default value that equals the number of CPUs
